### PR TITLE
Fix gradient decay validation to include 0.0

### DIFF
--- a/imgstax/config.py
+++ b/imgstax/config.py
@@ -69,8 +69,8 @@ class StackConfig:
         if self.trail_gradient and self.trail_length == 0:
             raise ValueError("Trail gradient requires trail_length > 0")
 
-        if not 0.0 < self.gradient_decay <= 1.0:
-            raise ValueError(f"Gradient decay must be between 0.0 and 1.0, got: {self.gradient_decay}")
+        if not 0.0 <= self.gradient_decay <= 1.0:
+            raise ValueError(f"Gradient decay must be between 0.0 and 1.0 (inclusive), got: {self.gradient_decay}")
 
         if self.gradient_plateau < 0:
             raise ValueError(f"Gradient plateau must be non-negative, got: {self.gradient_plateau}")


### PR DESCRIPTION
Changed validation from exclusive (0.0 < x <= 1.0) to inclusive (0.0 <= x <= 1.0) to allow 0.0 as a valid gradient decay value. This is useful for disabling gradient effects while keeping the trail gradient flag enabled.

Updated error message to clarify the range is inclusive.

Closes: #13 