### PR TITLE
Missed applying version updates to the documentation

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -16,20 +16,20 @@ Before building a release, update version numbers in these files:
 1. **desktop-app/src-tauri/tauri.conf.json**: Main app version
    ```json
    {
-     "version": "2.3.0"
+     "version": "2.4.0"
    }
    ```
 
 2. **desktop-app/package.json**: NPM package version
    ```json
    {
-     "version": "2.3.0"
+     "version": "2.4.0"
    }
    ```
 
 3. **imgstax/__init__.py**: Python package version (if changed)
    ```python
-   __version__ = "2.3.0"
+   __version__ = "2.4.0"
    ```
 
 **Version format**: Follow [Semantic Versioning](https://semver.org/) (MAJOR.MINOR.PATCH)
@@ -108,8 +108,8 @@ chmod +x desktop-app/src-tauri/target/release/bundle/appimage/imgstax_*.AppImage
 The generated installers are self-contained and can be distributed directly to users. No Python installation required!
 
 **GitHub Releases** (recommended):
-1. Create a version tag: `git tag -a v2.3.0 -m "Release v2.3.0"`
-2. Push the tag: `git push origin v2.3.0`
+1. Create a version tag: `git tag -a v2.4.0 -m "Release v2.4.0"`
+2. Push the tag: `git push origin v2.4.0`
 3. Create a GitHub Release and upload:
    - macOS: `.dmg` file
    - Windows: `.msi` file

--- a/README-CLI.md
+++ b/README-CLI.md
@@ -520,7 +520,7 @@ imgstax focuses on **progressive sequential stacking for animations**, not singl
 
 ## Version History
 
-### v2.3.0 (Current)
+### v2.4.0 (Current)
 - **Post-Processing System**: Run shell commands (ffmpeg, etc.) after stacking completes
 - **Expanded Image Format Support**: Added WebP, TGA, BMP, Netpbm support
 - **Gradient Documentation**: Detailed guide on stacking mode selection for subject contrast

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Create stunning **animated progressions** from image sequences with an intuitive
 
 ## Download
 
-### Latest Release (v2.3.0)
+### Latest Release (v2.4.0)
 
 - **macOS** (Apple Silicon): [Download DMG](https://github.com/repsac/imgstax/releases/latest)
 - **Windows** (x64): [Download MSI](https://github.com/repsac/imgstax/releases/latest)
@@ -485,7 +485,14 @@ imgstax focuses on **progressive sequential stacking for animations**, not singl
 
 ## Version History
 
-### v2.3.0 (Current)
+### v2.4.0 (Current)
+- **Completion Notification Sound**: System sound or TTS alert when stacking finishes (macOS/Windows)
+- **About Dialog**: Version, author, license, and GitHub link
+- **Window Size Constraints**: Max width/height prevent excessive whitespace
+- **Stacking Error Logging**: Error details surfaced in progress dialog; `stacking_error.log` written on failure
+- **Bug Fixes**: Reset clears file list/preview (#24, #25), output dir clears on input change, Windows notification terminal flash fixed (#28)
+
+### v2.3.0
 - **Post-Processing System**: Run shell commands (ffmpeg, ImageMagick, etc.) after stacking
 - **Post-Processing Recipes**: Create and manage OS-specific post-process commands
 - **Expanded Image Format Support**: Added WebP, TGA, BMP, Netpbm support

--- a/desktop-app/README.md
+++ b/desktop-app/README.md
@@ -89,8 +89,8 @@ npm run dev
 npm run build
 
 # Build output locations:
-# macOS:   src-tauri/target/release/bundle/dmg/imgstax_2.3.0_x64.dmg
-# Windows: src-tauri/target/release/bundle/msi/imgstax_2.3.0_x64_en-US.msi
+# macOS:   src-tauri/target/release/bundle/dmg/imgstax_2.4.0_x64.dmg
+# Windows: src-tauri/target/release/bundle/msi/imgstax_2.4.0_x64_en-US.msi
 # Linux:   src-tauri/target/release/bundle/appimage/imgstax.AppImage
 ```
 


### PR DESCRIPTION
THe builds are fine, no need to edit the releases. Just a documentation fix.